### PR TITLE
Add API blueprint and ping endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from .config import Config
 from .cli import register_cli
+from .api import api_bp
 from .extensions import db, migrate
 from . import models
 
@@ -11,6 +12,8 @@ def create_app():
 
     db.init_app(app)
     migrate.init_app(app, db)
+    app.register_blueprint(api_bp, url_prefix="/api/v1")
+
 
     @app.get("/health")
     def health():

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+api_bp = Blueprint("api", __name__)
+
+from . import routes

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,0 +1,6 @@
+from . import api_bp
+
+
+@api_bp.get("/ping")
+def ping():
+    return {"message": "pong"}


### PR DESCRIPTION
Introduced a new api package to organize HTTP endpoints under a Flask Blueprint.

Added api_bp blueprint in app/api/__init__.py and ensured routes are imported to register endpoints.

Implemented a simple GET /api/v1/ping endpoint for smoke testing the API layer.

Registered the blueprint in the application factory with url_prefix="/api/v1".

Verified routes are discoverable via flask routes and the ping endpoint responds successfully.

This establishes a clean foundation for adding future API modules and endpoints.