### PR TITLE
Add API error handling and JSON helpers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 from .config import Config
 from .cli import register_cli
 from .api import api_bp
+from .api.errors import register_api_error_handlers
 from .extensions import db, migrate
 from . import models
 
@@ -12,6 +13,7 @@ def create_app():
 
     db.init_app(app)
     migrate.init_app(app, db)
+    register_api_error_handlers(app)
     app.register_blueprint(api_bp, url_prefix="/api/v1")
 
 

--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from flask import Flask
+from werkzeug.exceptions import HTTPException
+
+from .utils import error
+
+
+def register_api_error_handlers(app: Flask):
+    @app.errorhandler(404)
+    def not_found(_e):
+        return error("Not Found", 404)
+
+    @app.errorhandler(405)
+    def method_not_allowed(_e):
+        return error("Method Not Allowed", 405)
+
+    @app.errorhandler(400)
+    def bad_request(_e):
+        return error("Bad Request", 400)
+
+    @app.errorhandler(500)
+    def internal_error(_e):
+        return error("Internal Server Error", 500)
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(e: HTTPException):
+        return error(e.description or "HTTP Error", e.code or 500)

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from flask import request
+
+
+def ok(data=None, status_code: int = 200):
+    payload = {"ok": True}
+    if data is not None:
+        payload["data"] = data
+    return payload, status_code
+
+
+def error(message: str, status_code: int = 400, details=None):
+    payload = {"ok": False, "error": {"message": message}}
+    if details is not None:
+        payload["error"]["details"] = details
+    return payload, status_code
+
+
+def get_json_or_error(required: bool = True):
+    """
+    Returns parsed JSON dict or (error_payload, status_code) tuple.
+    """
+    if not request.is_json:
+        if required:
+            return error("Request must be JSON", 415)
+        return {}
+    data = request.get_json(silent=True)
+    if data is None:
+        return error("Invalid JSON body", 400)
+    if not isinstance(data, dict):
+        return error("JSON body must be an object", 400)
+    return data


### PR DESCRIPTION
Added ok() and error() response helpers for consistent API payloads.

Implemented get_json_or_error() to safely parse request bodies.

Registered centralized HTTP error handlers (404/405/400/500) to return JSON.

Ensures API responses remain predictable and easier to test/consume.

