### PR TITLE
feat: add utils, decorators, and seed module per documentation

### DIFF
--- a/app/decorators.py
+++ b/app/decorators.py
@@ -1,0 +1,24 @@
+from functools import wraps
+from flask import redirect, url_for, flash
+from .auth.services import get_current_user
+
+def login_required(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not get_current_user():
+            flash("Please login first.", "warning")
+            return redirect(url_for("auth.login"))
+        return fn(*args, **kwargs)
+    return wrapper
+
+def role_required(role: str):
+    def deco(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            u = get_current_user()
+            if not u or u.role != role:
+                flash("Access denied.", "danger")
+                return redirect(url_for("dashboard.dashboard"))
+            return fn(*args, **kwargs)
+        return wrapper
+    return deco

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,3 +1,35 @@
+from .extensions import db
+from .models import User, Course, Enrollment, Grade, Announcement
+
 def seed_demo_data():
-    
-    pass
+    if User.query.first():
+        return
+
+    instructor = User(name="Dr Instructor", email="instructor@demo.com", role="instructor")
+    instructor.set_password("1234")
+
+    s1 = User(name="Ahmed Student", email="student1@demo.com", role="student"); s1.set_password("1234")
+    s2 = User(name="Mona Student", email="student2@demo.com", role="student"); s2.set_password("1234")
+
+    db.session.add_all([instructor, s1, s2])
+    db.session.flush()
+
+    c1 = Course(code="CS101", title="Intro to Programming")
+    c2 = Course(code="SE201", title="Software Engineering")
+    db.session.add_all([c1, c2])
+    db.session.flush()
+
+    db.session.add_all([
+        Enrollment(user_id=s1.id, course_id=c1.id),
+        Enrollment(user_id=s1.id, course_id=c2.id),
+        Enrollment(user_id=s2.id, course_id=c1.id),
+    ])
+
+    db.session.add_all([
+        Grade(user_id=s1.id, course_id=c1.id, item_name="Midterm", score=28),
+        Grade(user_id=s1.id, course_id=c2.id, item_name="Quiz", score=15),
+        Grade(user_id=s2.id, course_id=c1.id, item_name="Midterm", score=25),
+    ])
+
+    db.session.add(Announcement(title="Welcome", body="Welcome to the Student Portal!"))
+    db.session.commit()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,5 @@
+def normalize_email(email: str) -> str:
+    return (email or "").strip().lower()
+
+def safe_str(s: str) -> str:
+    return (s or "").strip()


### PR DESCRIPTION
This pull request adds the missing cross-cutting modules that are required by the Phase 2 documentation and target project structure.

It introduces a small utilities module used for consistent input handling (e.g., normalizing emails), adds route decorators for login and role-based access control (to be used by feature routes), and replaces the temporary seed stub with the full demo seeding logic that matches the documented demo accounts and sample data.

These additions complete an important part of the core foundation and prepare the project for implementing the actual feature modules (auth, dashboard, courses, grades, announcements, profile, search) in the next step.